### PR TITLE
Upgrade vinyldns

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ start-api:
 		git clone https://$(VINYLDNS_REPO) $(GOPATH)/src/$(VINYLDNS_REPO); \
 	fi
 	$(GOPATH)/src/$(VINYLDNS_REPO)/bin/docker-up-vinyldns.sh \
-		--version 0.9.0 \
+		--version 0.9.1 \
 		--api-only
 
 stop-api:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ NAME=terraform-provider-vinyldns
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 SOURCE=./...
-VERSION=0.8.3
+VERSION=0.9.0
 
 all: deps start-api test build stop-api
 deps-build: deps build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ start-api:
 		git clone https://$(VINYLDNS_REPO) $(GOPATH)/src/$(VINYLDNS_REPO); \
 	fi
 	$(GOPATH)/src/$(VINYLDNS_REPO)/bin/docker-up-vinyldns.sh \
-		--version 0.8.0 \
+		--version 0.9.0 \
 		--api-only
 
 stop-api:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -436,12 +436,12 @@
   version = "v0.5.4"
 
 [[projects]]
-  digest = "1:631cb5c3d8fc4cf5c18b604810c0dd3db6228f9f6d0cb25115ea6929278f6c35"
+  digest = "1:7b585efe42e947db032913b300c9a83d816d6a34808f59646cd1790763d6746d"
   name = "github.com/vinyldns/go-vinyldns"
   packages = ["vinyldns"]
   pruneopts = "UT"
-  revision = "6d0bbf52fa7710eff0f6ff9721b7f6b2b36dd41d"
-  version = "0.8.4"
+  revision = "2f812db83bea8431d15652b009b2af4a4d8ec51b"
+  version = "0.9.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/vinyldns/go-vinyldns"
-  version = "0.8.4"
+  version = "0.9.1"
 
 [prune]
   go-tests = true

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -76,7 +76,7 @@ func resourceVinylDNSRecordSetCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	created, err := meta.(*vinyldns.Client).RecordSetCreate(d.Get("zone_id").(string), &vinyldns.RecordSet{
+	created, err := meta.(*vinyldns.Client).RecordSetCreate(&vinyldns.RecordSet{
 		Name:    d.Get("name").(string),
 		ZoneID:  d.Get("zone_id").(string),
 		Type:    d.Get("type").(string),
@@ -115,7 +115,7 @@ func resourceVinylDNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	updated, err := meta.(*vinyldns.Client).RecordSetUpdate(d.Get("zone_id").(string), d.Id(), &vinyldns.RecordSet{
+	updated, err := meta.(*vinyldns.Client).RecordSetUpdate(&vinyldns.RecordSet{
 		Name:    d.Get("name").(string),
 		ID:      d.Id(),
 		ZoneID:  d.Get("zone_id").(string),


### PR DESCRIPTION
Upgrade provider's `go-vinyldns` version to 0.9.1 in preparation for use with VinylDNS 0.9.