### PR TITLE
ensure Zone.Shared is present when updating zone

### DIFF
--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -46,6 +46,10 @@ func resourceVinylDNSZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"shared": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"created": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -300,6 +304,11 @@ func zone(d *schema.ResourceData) *vinyldns.Zone {
 
 	if d.Get("transfer_connection.0.name").(string) != "" {
 		zone.TransferConnection = transferConnection(d)
+	}
+
+	shared := d.Get("shared").(bool)
+	if shared == true || shared == false {
+		zone.Shared = shared
 	}
 
 	return zone


### PR DESCRIPTION
This seeks to provide partial support to issue #13.

In particular, this PR aspires to ensure that the `shared` attribute is present...

* in saved tfstate if the Terraform-orchestrated "zone create" request returns a response with a `shared: true||false` attributed
* in an "update zone" request if the the zone is stored in tfstate with `shared: true||false` attribute

Is this the correct behavior? And implementation?