### PR TITLE
Support ownerGroupId

### DIFF
--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -29,6 +29,10 @@ func resourceVinylDNSRecordSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"owner_group_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -73,11 +77,12 @@ func resourceVinylDNSRecordSetCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	created, err := meta.(*vinyldns.Client).RecordSetCreate(&vinyldns.RecordSet{
-		Name:    d.Get("name").(string),
-		ZoneID:  d.Get("zone_id").(string),
-		Type:    d.Get("type").(string),
-		TTL:     d.Get("ttl").(int),
-		Records: records,
+		Name:         d.Get("name").(string),
+		ZoneID:       d.Get("zone_id").(string),
+		OwnerGroupID: d.Get("owner_group_id").(string),
+		Type:         d.Get("type").(string),
+		TTL:          d.Get("ttl").(int),
+		Records:      records,
 	})
 	if err != nil {
 		return err
@@ -112,12 +117,13 @@ func resourceVinylDNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	updated, err := meta.(*vinyldns.Client).RecordSetUpdate(&vinyldns.RecordSet{
-		Name:    d.Get("name").(string),
-		ID:      d.Id(),
-		ZoneID:  d.Get("zone_id").(string),
-		Type:    d.Get("type").(string),
-		TTL:     d.Get("ttl").(int),
-		Records: records,
+		Name:         d.Get("name").(string),
+		ID:           d.Id(),
+		ZoneID:       d.Get("zone_id").(string),
+		OwnerGroupID: d.Get("owner_group_id").(string),
+		Type:         d.Get("type").(string),
+		TTL:          d.Get("ttl").(int),
+		Records:      records,
 	})
 	if err != nil {
 		return err

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -37,10 +37,6 @@ func resourceVinylDNSRecordSet() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"account": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"record_addresses": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -134,6 +134,7 @@ resource "vinyldns_zone" "test_zone" {
 resource "vinyldns_record_set" "test_a_record_set" {
 	name = "terraformtestrecordset"
 	zone_id = "${vinyldns_zone.test_zone.id}"
+	owner_group_id = "${vinyldns_group.test_group.id}"
 	type = "A"
 	ttl = 6000
 	record_addresses = ["127.0.0.1", "127.0.0.1"]


### PR DESCRIPTION
This seeks to address issue #13 -- at least in part -- by supporting the option for users to specify a `owner_group_id` on record sets.

This also removes the `account` attribute from record sets, as this has been [deprecated](https://www.vinyldns.io/api/recordset-model.html) according to VinylDNS docs.

The `resource_record_set_test.go` tests seek to ensure...
* the presence of `owner_group_id` does not impede record creation
* the absence of an `owner_group_id` does not impede record creation