### PR TITLE
Refresh state on read

### DIFF
--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -73,6 +73,23 @@ func resourceVinylDNSGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", g.Name)
+	d.Set("email", g.Email)
+	d.Set("description", g.Description)
+	if g.Members != nil {
+		mems := schemaUsers(g.Members)
+
+		if err := d.Set("member", mems); err != nil {
+			return err
+		}
+	}
+
+	if g.Admins != nil {
+		admins := schemaUsers(g.Admins)
+
+		if err := d.Set("admin", admins); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -160,4 +177,23 @@ func users(userType string, d *schema.ResourceData) []vinyldns.User {
 	}
 
 	return users
+}
+
+func schemaUsers(users []vinyldns.User) []map[string]interface{} {
+	var saves []map[string]interface{}
+
+	for _, user := range users {
+		u := make(map[string]interface{})
+
+		u["user_name"] = user.UserName
+		u["first_name"] = user.FirstName
+		u["last_name"] = user.LastName
+		u["email"] = user.Email
+		u["created"] = user.Created
+		u["id"] = user.ID
+
+		saves = append(saves, u)
+	}
+
+	return saves
 }

--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -13,7 +13,6 @@ limitations under the License.
 package vinyldns
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -126,7 +125,7 @@ func resourceVinylDNSGroupDelete(d *schema.ResourceData, meta interface{}) error
 
 func userSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -161,19 +160,22 @@ func userSchema() *schema.Schema {
 
 func users(userType string, d *schema.ResourceData) []vinyldns.User {
 	users := []vinyldns.User{}
-	usersCount := d.Get(fmt.Sprintf("%s.#", userType)).(int)
 
-	for i := 0; i < usersCount; i++ {
-		prefix := fmt.Sprintf("%s.%d", userType, i)
+	if u, ok := d.GetOk(userType); ok {
+		schemaUsers := u.(*schema.Set).List()
 
-		users = append(users, vinyldns.User{
-			UserName:  d.Get(prefix + ".user_name").(string),
-			FirstName: d.Get(prefix + ".first_name").(string),
-			LastName:  d.Get(prefix + ".last_name").(string),
-			Email:     d.Get(prefix + ".email").(string),
-			Created:   d.Get(prefix + ".created").(string),
-			ID:        d.Get(prefix + ".id").(string),
-		})
+		for _, user := range schemaUsers {
+			u := user.(map[string]interface{})
+
+			users = append(users, vinyldns.User{
+				UserName:  u["user_name"].(string),
+				FirstName: u["first_name"].(string),
+				LastName:  u["last_name"].(string),
+				Email:     u["email"].(string),
+				Created:   u["created"].(string),
+				ID:        u["id"].(string),
+			})
+		}
 	}
 
 	return users

--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -13,6 +13,7 @@ limitations under the License.
 package vinyldns
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -79,7 +80,7 @@ func resourceVinylDNSGroupRead(d *schema.ResourceData, meta interface{}) error {
 		mems := schemaUsers(g.Members)
 
 		if err := d.Set("member", mems); err != nil {
-			return err
+			return fmt.Errorf("error setting member for group %s: %s", d.Id(), err)
 		}
 	}
 
@@ -87,7 +88,7 @@ func resourceVinylDNSGroupRead(d *schema.ResourceData, meta interface{}) error {
 		admins := schemaUsers(g.Admins)
 
 		if err := d.Set("admin", admins); err != nil {
-			return err
+			return fmt.Errorf("error setting admin for group %s: %s", d.Id(), err)
 		}
 	}
 

--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -21,10 +21,11 @@ import (
 
 func resourceVinylDNSGroup() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVinylDNSGroupCreate,
-		Read:   resourceVinylDNSGroupRead,
-		Update: resourceVinylDNSGroupUpdate,
-		Delete: resourceVinylDNSGroupDelete,
+		SchemaVersion: 1,
+		Create:        resourceVinylDNSGroupCreate,
+		Read:          resourceVinylDNSGroupRead,
+		Update:        resourceVinylDNSGroupUpdate,
+		Delete:        resourceVinylDNSGroupDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_group_test.go
+++ b/vinyldns/resource_group_test.go
@@ -91,4 +91,10 @@ resource "vinyldns_group" "test_group" {
 	name = "terraformtestgroup"
 	description = "some description"
 	email = "tftest@tf.com"
+	member {
+	  id = "ok"
+	}
+	admin {
+	  id = "ok"
+	}
 }`

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -15,10 +15,11 @@ import (
 
 func resourceVinylDNSRecordSet() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVinylDNSRecordSetCreate,
-		Read:   resourceVinylDNSRecordSetRead,
-		Update: resourceVinylDNSRecordSetUpdate,
-		Delete: resourceVinylDNSRecordSetDelete,
+		SchemaVersion: 1,
+		Create:        resourceVinylDNSRecordSetCreate,
+		Read:          resourceVinylDNSRecordSetRead,
+		Update:        resourceVinylDNSRecordSetUpdate,
+		Delete:        resourceVinylDNSRecordSetDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -2,6 +2,7 @@ package vinyldns
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -136,7 +137,9 @@ func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) err
 			recs = append(recs, r.NSDName)
 		}
 
-		d.Set("record_nsdnames", schema.NewSet(schema.HashString, recs))
+		if err := d.Set("record_nsdnames", schema.NewSet(schema.HashString, recs)); err != nil {
+			return fmt.Errorf("error setting record_nsdnames for record set %s: %s", d.Id(), err)
+		}
 
 		return nil
 	}
@@ -146,7 +149,9 @@ func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) err
 		recs = append(recs, r.Address)
 	}
 
-	d.Set("record_addresses", schema.NewSet(schema.HashString, recs))
+	if err := d.Set("record_addresses", schema.NewSet(schema.HashString, recs)); err != nil {
+		return fmt.Errorf("error setting record_addresses for record set %s: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -104,8 +104,48 @@ func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
+	recordType := strings.ToLower(rs.Type)
+
+	if recordType == "soa" {
+		return errors.New(recordType + " records are not currently supported by vinyldns")
+	}
 
 	d.Set("name", rs.Name)
+	d.Set("zone_id", rs.ZoneID)
+	d.Set("ttl", rs.TTL)
+	d.Set("type", rs.Type)
+	d.Set("owner_group_id", rs.OwnerGroupID)
+
+	if recordType == "cname" {
+		d.Set("record_cname", rs.Records[0].CName)
+
+		return nil
+	}
+
+	if recordType == "txt" {
+		d.Set("record_text", rs.Records[0].Text)
+
+		return nil
+	}
+
+	if recordType == "ns" {
+		recs := make([]interface{}, 0, len(rs.Records))
+
+		for _, r := range rs.Records {
+			recs = append(recs, r.NSDName)
+		}
+
+		d.Set("record_nsdnames", schema.NewSet(schema.HashString, recs))
+
+		return nil
+	}
+
+	recs := make([]interface{}, 0, len(rs.Records))
+	for _, r := range rs.Records {
+		recs = append(recs, r.Address)
+	}
+
+	d.Set("record_addresses", schema.NewSet(schema.HashString, recs))
 
 	return nil
 }

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -35,7 +35,6 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					testAccCheckVinylDNSRecordSetExists("vinyldns_record_set.test_txt_record_set"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "name", "terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "name", "cname-terraformtestrecordset"),
-					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "name", "txt-terraformtestrecordset"),
 				),
 			},
 		},
@@ -165,7 +164,7 @@ resource "vinyldns_record_set" "test_txt_record_set" {
 	zone_id = "${vinyldns_zone.test_zone.id}"
 	type = "TXT"
 	ttl = 6000
-	record_text = "Lorem ipsum and all that jazz"
+	record_texts = ["Lorem ipsum and all that jazz"]
 	depends_on = [
 		"vinyldns_zone.test_zone"
 	]

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -120,6 +120,12 @@ resource "vinyldns_group" "test_group" {
 	name = "terraformtestgroup"
 	description = "some description"
 	email = "tftest@tf.com"
+	member {
+	  id = "ok"
+	}
+	admin {
+	  id = "ok"
+	}
 }
 
 resource "vinyldns_zone" "test_zone" {

--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -24,10 +24,11 @@ import (
 
 func resourceVinylDNSZone() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVinylDNSZoneCreate,
-		Read:   resourceVinylDNSZoneRead,
-		Update: resourceVinylDNSZoneUpdate,
-		Delete: resourceVinylDNSZoneDelete,
+		SchemaVersion: 1,
+		Create:        resourceVinylDNSZoneCreate,
+		Read:          resourceVinylDNSZoneRead,
+		Update:        resourceVinylDNSZoneUpdate,
+		Delete:        resourceVinylDNSZoneDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -90,6 +91,33 @@ func resourceVinylDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", zone.Name)
+	d.Set("email", zone.Email)
+	d.Set("admin_group_id", zone.AdminGroupID)
+	d.Set("status", zone.Status)
+	d.Set("shared", zone.Shared)
+	d.Set("created", zone.Created)
+
+	if zone.Connection != nil {
+		d.Set("zone_connection", []interface{}{
+			map[string]interface{}{
+				"name":           zone.Connection.Name,
+				"key":            zone.Connection.Key,
+				"key_name":       zone.Connection.KeyName,
+				"primary_server": zone.Connection.PrimaryServer,
+			},
+		})
+	}
+
+	if zone.TransferConnection != nil {
+		d.Set("transfer_connection", []interface{}{
+			map[string]interface{}{
+				"name":           zone.TransferConnection.Name,
+				"key":            zone.TransferConnection.Key,
+				"key_name":       zone.TransferConnection.KeyName,
+				"primary_server": zone.TransferConnection.PrimaryServer,
+			},
+		})
+	}
 
 	return nil
 }

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -94,7 +94,14 @@ resource "vinyldns_group" "test_group" {
 	name = "terraformtestgroup"
 	description = "some description"
 	email = "tftest@tf.com"
+	member {
+	  id = "ok"
+	}
+	admin {
+	  id = "ok"
+	}
 }
+
 resource "vinyldns_zone" "test_zone" {
 	name = "system-test."
 	email = "foo@bar.com"


### PR DESCRIPTION
* do a "set" of state on each resource "read," in effect "refreshing" state on read, paving a path towards which the provider can support import functionality per issue #12 
* version each `schema.Resource` (partial implementation of issue #19), paving a path towards which `StateUpgraders` can be leveraged to migrate users' tfstate between `terraform-provider-vinyldns` versions
* properly store group `member` and `admin` in tfstate (issue #22)
* fix issue #31 and support TXT records with multiple values