### PR TITLE
Support Import

### DIFF
--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -27,6 +27,9 @@ func resourceVinylDNSGroup() *schema.Resource {
 		Read:          resourceVinylDNSGroupRead,
 		Update:        resourceVinylDNSGroupUpdate,
 		Delete:        resourceVinylDNSGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_group_test.go
+++ b/vinyldns/resource_group_test.go
@@ -35,6 +35,11 @@ func TestAccVinylDNSGroupBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_group.test_group", "name", "terraformtestgroup"),
 				),
 			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_group.test_group",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/vinyldns/resource_group_test.go
+++ b/vinyldns/resource_group_test.go
@@ -39,6 +39,7 @@ func TestAccVinylDNSGroupBasic(t *testing.T) {
 				ResourceName:      "vinyldns_group.test_group",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSGroupImportStateCheck,
 			},
 		},
 	})
@@ -59,6 +60,34 @@ func TestAccVinylDNSGroupWithoutDescription(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccVinylDNSGroupImportStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "terraformtestgroup"
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expDesc := "some description"
+	desc := rs.Attributes["description"]
+	if desc != expDesc {
+		return fmt.Errorf("expected description attribute to be %s, received %s", expDesc, desc)
+	}
+
+	expEmail := "tftest@tf.com"
+	email := rs.Attributes["email"]
+	if email != expEmail {
+		return fmt.Errorf("expected email attribute to be %s, received %s", expEmail, email)
+	}
+
+	return nil
 }
 
 func testAccVinylDNSGroupDestroy(s *terraform.State) error {

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -21,6 +21,9 @@ func resourceVinylDNSRecordSet() *schema.Resource {
 		Read:          resourceVinylDNSRecordSetRead,
 		Update:        resourceVinylDNSRecordSetUpdate,
 		Delete:        resourceVinylDNSRecordSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -37,6 +37,21 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "name", "cname-terraformtestrecordset"),
 				),
 			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_record_set.test_a_record_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_record_set.test_cname_record_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_record_set.test_txt_record_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -47,6 +47,7 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 				ResourceName:      "vinyldns_record_set.test_cname_record_set",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSRecordSetImportCNAMERecordStateCheck,
 			},
 			resource.TestStep{
 				ResourceName:      "vinyldns_record_set.test_txt_record_set",
@@ -80,6 +81,40 @@ func testAccVinylDNSRecordSetImportARecordStateCheck(s []*terraform.InstanceStat
 	ttl := rs.Attributes["ttl"]
 	if ttl != expTTL {
 		return fmt.Errorf("expected ttl attribute to be %s, received %s", expTTL, ttl)
+	}
+
+	return nil
+}
+
+func testAccVinylDNSRecordSetImportCNAMERecordStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "cname-terraformtestrecordset"
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expType := "CNAME"
+	aType := rs.Attributes["type"]
+	if aType != expType {
+		return fmt.Errorf("expected type attribute to be %s, received %s", expType, aType)
+	}
+
+	expTTL := "6000"
+	ttl := rs.Attributes["ttl"]
+	if ttl != expTTL {
+		return fmt.Errorf("expected ttl attribute to be %s, received %s", expTTL, ttl)
+	}
+
+	expRecordCNAME := "terraformtestrecordset.system-test."
+	recordCNAME := rs.Attributes["record_cname"]
+	if recordCNAME != expRecordCNAME {
+		return fmt.Errorf("expected record_cname attribute to be %s, received %s", expRecordCNAME, recordCNAME)
 	}
 
 	return nil

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -34,7 +34,17 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					testAccCheckVinylDNSRecordSetExists("vinyldns_record_set.test_cname_record_set"),
 					testAccCheckVinylDNSRecordSetExists("vinyldns_record_set.test_txt_record_set"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "name", "terraformtestrecordset"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "type", "A"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "ttl", "6000"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "name", "cname-terraformtestrecordset"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "type", "CNAME"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "ttl", "6000"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "name", "txt-terraformtestrecordset"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "type", "TXT"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "ttl", "6000"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "name", "ns-terraformtestrecordset"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "type", "NS"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "ttl", "6000"),
 				),
 			},
 			resource.TestStep{
@@ -250,8 +260,8 @@ resource "vinyldns_record_set" "test_txt_record_set" {
 	]
 }
 
-resource "vinyldns_record_set" "test_nsd_record_set" {
-	name = "nsd-terraformtestrecordset"
+resource "vinyldns_record_set" "test_ns_record_set" {
+	name = "ns-terraformtestrecordset"
 	zone_id = "${vinyldns_zone.test_zone.id}"
 	type = "NS"
 	ttl = 6000

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -65,6 +65,12 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateCheck:  testAccVinylDNSRecordSetImportTXTRecordStateCheck,
 			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_record_set.test_ns_record_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSRecordSetImportNSRecordStateCheck,
+			},
 		},
 	})
 }
@@ -145,6 +151,34 @@ func testAccVinylDNSRecordSetImportTXTRecordStateCheck(s []*terraform.InstanceSt
 	}
 
 	expType := "TXT"
+	aType := rs.Attributes["type"]
+	if aType != expType {
+		return fmt.Errorf("expected type attribute to be %s, received %s", expType, aType)
+	}
+
+	expTTL := "6000"
+	ttl := rs.Attributes["ttl"]
+	if ttl != expTTL {
+		return fmt.Errorf("expected ttl attribute to be %s, received %s", expTTL, ttl)
+	}
+
+	return nil
+}
+
+func testAccVinylDNSRecordSetImportNSRecordStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "ns-terraformtestrecordset"
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expType := "NS"
 	aType := rs.Attributes["type"]
 	if aType != expType {
 		return fmt.Errorf("expected type attribute to be %s, received %s", expType, aType)

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -53,6 +53,7 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 				ResourceName:      "vinyldns_record_set.test_txt_record_set",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSRecordSetImportTXTRecordStateCheck,
 			},
 		},
 	})
@@ -115,6 +116,34 @@ func testAccVinylDNSRecordSetImportCNAMERecordStateCheck(s []*terraform.Instance
 	recordCNAME := rs.Attributes["record_cname"]
 	if recordCNAME != expRecordCNAME {
 		return fmt.Errorf("expected record_cname attribute to be %s, received %s", expRecordCNAME, recordCNAME)
+	}
+
+	return nil
+}
+
+func testAccVinylDNSRecordSetImportTXTRecordStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "txt-terraformtestrecordset"
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expType := "TXT"
+	aType := rs.Attributes["type"]
+	if aType != expType {
+		return fmt.Errorf("expected type attribute to be %s, received %s", expType, aType)
+	}
+
+	expTTL := "6000"
+	ttl := rs.Attributes["ttl"]
+	if ttl != expTTL {
+		return fmt.Errorf("expected ttl attribute to be %s, received %s", expTTL, ttl)
 	}
 
 	return nil

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -41,6 +41,7 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 				ResourceName:      "vinyldns_record_set.test_a_record_set",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSRecordSetImportARecordStateCheck,
 			},
 			resource.TestStep{
 				ResourceName:      "vinyldns_record_set.test_cname_record_set",
@@ -54,6 +55,34 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccVinylDNSRecordSetImportARecordStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "terraformtestrecordset"
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expType := "A"
+	aType := rs.Attributes["type"]
+	if aType != expType {
+		return fmt.Errorf("expected type attribute to be %s, received %s", expType, aType)
+	}
+
+	expTTL := "6000"
+	ttl := rs.Attributes["ttl"]
+	if ttl != expTTL {
+		return fmt.Errorf("expected ttl attribute to be %s, received %s", expTTL, ttl)
+	}
+
+	return nil
 }
 
 func testAccVinylDNSRecordSetDestroy(s *terraform.State) error {

--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -29,6 +29,9 @@ func resourceVinylDNSZone() *schema.Resource {
 		Read:          resourceVinylDNSZoneRead,
 		Update:        resourceVinylDNSZoneUpdate,
 		Delete:        resourceVinylDNSZoneDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -28,13 +28,18 @@ func TestAccVinylDNSZoneBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccVinylDNSZoneDestroy,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccVinylDNSZoneConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVinylDNSZoneExists("vinyldns_zone.test_zone"),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "foo@bar.com"),
 				),
+			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_zone.test_zone",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -40,9 +40,32 @@ func TestAccVinylDNSZoneBasic(t *testing.T) {
 				ResourceName:      "vinyldns_zone.test_zone",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSZoneImportStateCheck,
 			},
 		},
 	})
+}
+
+func testAccVinylDNSZoneImportStateCheck(s []*terraform.InstanceState) error {
+	if len(s) != 1 {
+		return fmt.Errorf("expected 1 state: %#v", s)
+	}
+
+	rs := s[0]
+
+	expName := "system-test."
+	name := rs.Attributes["name"]
+	if name != expName {
+		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
+	}
+
+	expEmail := "foo@bar.com"
+	email := rs.Attributes["email"]
+	if email != expEmail {
+		return fmt.Errorf("expected email attribute to be %s, received %s", expEmail, email)
+	}
+
+	return nil
 }
 
 func testAccVinylDNSZoneDestroy(s *terraform.State) error {


### PR DESCRIPTION
This addresses issue #12. Summary:

* declare an `Importer` callback on each resource and leverage [schema.ImportStatePassthrough](https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_importer.go#L47-L52), which enables the resource to refresh state with the resource ID on read
* leverage [TestStep.ImportStateVerify](https://godoc.org/github.com/hashicorp/terraform/helper/resource#TestStep) in tests, which checks that the state values put into the state after import match for all the IDs returned by the Import.
* leverage [TestStep.ImportStateCheckFunc](https://godoc.org/github.com/hashicorp/terraform/helper/resource#ImportStateCheckFunc) in tests, which validates the resource attribute values resulting from an import
* make the recordset resource ID a 2-part `:`-delimited ID composed of `THE_ZONE_ID:THE_RECORDSET_ID`. This is necessary for `import` functionality, as `import` requires a state refresh on `Read`, but VinylDNS requires both the zone ID as well as the recordset ID to look up a recordset