### PR TITLE
Add default value for Group description

### DIFF
--- a/vinyldns/resource_group.go
+++ b/vinyldns/resource_group.go
@@ -40,6 +40,7 @@ func resourceVinylDNSGroup() *schema.Resource {
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 			"member": userSchema(),
 			"admin":  userSchema(),

--- a/vinyldns/resource_group_test.go
+++ b/vinyldns/resource_group_test.go
@@ -39,6 +39,23 @@ func TestAccVinylDNSGroupBasic(t *testing.T) {
 	})
 }
 
+func TestAccVinylDNSGroupWithoutDescription(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVinylDNSGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVinylDNSGroupConfigWithoutDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVinylDNSGroupExists("vinyldns_group.test_group"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "description", "Managed by Terraform"),
+				),
+			},
+		},
+	})
+}
+
 func testAccVinylDNSGroupDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*vinyldns.Client)
 
@@ -78,7 +95,7 @@ func testAccCheckVinylDNSGroupExists(n string) resource.TestCheckFunc {
 		if g.Name != "terraformtestgroup" {
 			return fmt.Errorf("Group not found")
 		}
-		if g.Description != "some description" {
+		if g.Description == "" {
 			return fmt.Errorf("Group 'description' not set")
 		}
 
@@ -90,6 +107,18 @@ const testAccVinylDNSGroupConfigBasic = `
 resource "vinyldns_group" "test_group" {
 	name = "terraformtestgroup"
 	description = "some description"
+	email = "tftest@tf.com"
+	member {
+	  id = "ok"
+	}
+	admin {
+	  id = "ok"
+	}
+}`
+
+const testAccVinylDNSGroupConfigWithoutDescription = `
+resource "vinyldns_group" "test_group" {
+	name = "terraformtestgroup"
 	email = "tftest@tf.com"
 	member {
 	  id = "ok"


### PR DESCRIPTION
## Description of the Change

Terraform will set a default value(Managed by Terraform)
for the description field of the Group resource if it is not set.

## Why Should This Be In The Package?

Good user experience, similar behavior to other providers

## Benefits

Good user experience, similar behavior to other providers

## Possible Drawbacks

For folks that do not have a description set, running a plan will show a change needs to happen

## Verification Process

* Wrote a test
* Ran the branch against vinyl and saw the description field set

```
Terraform will perform the following actions:

  + vinyldns_group.admin_group
      id:          <computed>
      description: "Managed by Terraform"
```

## Applicable Issues (Optional)

#33 