### PR TITLE
add `acl_rule` to Zone

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -436,12 +436,12 @@
   version = "v0.5.4"
 
 [[projects]]
-  digest = "1:19ff7220e5dcd236115d855688428d6671cc7e611566a43bd59d97a1dd2fb688"
+  digest = "1:bae69942a6b19d7788763c89a1f199248535d4af27293c47d9347af9bb29f292"
   name = "github.com/vinyldns/go-vinyldns"
   packages = ["vinyldns"]
   pruneopts = "UT"
-  revision = "0c6fa243f98b9a60127bef27c50badcf83c11682"
-  version = "0.9.3"
+  revision = "c359129add72bb1f07339392867bcc63741d70cd"
+  version = "0.9.4"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/vinyldns/go-vinyldns"
-  version = "0.9.3"
+  version = "0.9.4"
 
 [prune]
   go-tests = true

--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -91,7 +91,9 @@ func resourceVinylDNSZone() *schema.Resource {
 						"record_types": &schema.Schema{
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},
@@ -454,7 +456,7 @@ func aclRecordTypes(rt *schema.Set) []string {
 }
 
 func buildACLRules(rules *vinyldns.ZoneACL) []map[string]interface{} {
-	var saves []map[string]interface{}
+	saves := []map[string]interface{}{}
 
 	for _, rule := range rules.Rules {
 		saves = append(saves, buildACLRule(rule))
@@ -472,7 +474,7 @@ func buildACLRule(rule vinyldns.ACLRule) map[string]interface{} {
 	r["group_id"] = rule.GroupID
 	r["record_mask"] = rule.RecordMask
 
-	rTypes := []string{}
+	rTypes := make([]string, 0, len(rule.RecordTypes))
 	for _, rt := range rule.RecordTypes {
 		rTypes = append(rTypes, rt)
 	}

--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -60,6 +60,14 @@ func resourceVinylDNSZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"updated": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_sync": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"transfer_connection": connectionSchema(),
 			"zone_connection":     connectionSchema(),
 			"acl_rule": &schema.Schema{
@@ -149,6 +157,8 @@ func resourceVinylDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", zone.Status)
 	d.Set("shared", zone.Shared)
 	d.Set("created", zone.Created)
+	d.Set("updated", zone.Updated)
+	d.Set("latest_sync", zone.LatestSync)
 
 	if zone.ACL != nil {
 		acls := buildACLRules(zone.ACL)

--- a/vinyldns/resource_zone.go
+++ b/vinyldns/resource_zone.go
@@ -474,13 +474,20 @@ func buildACLRule(rule vinyldns.ACLRule) map[string]interface{} {
 	r["group_id"] = rule.GroupID
 	r["record_mask"] = rule.RecordMask
 
-	rTypes := make([]string, 0, len(rule.RecordTypes))
+	if len(rule.RecordTypes) <= 0 {
+		return r
+	}
+
+	raw, ok := r["record_types"]
+	if !ok {
+		raw = schema.NewSet(schema.HashString, nil)
+	}
+
+	list := raw.(*schema.Set)
 	for _, rt := range rule.RecordTypes {
-		rTypes = append(rTypes, rt)
+		list.Add(rt)
 	}
-	if len(rTypes) > 0 {
-		r["record_types"] = rTypes
-	}
+	r["record_types"] = list
 
 	return r
 }

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -245,6 +245,7 @@ resource "vinyldns_zone" "test_zone" {
 	acl_rule {
 		access_level = "Delete"
 		group_id = "${vinyldns_group.test_group.id}"
+		record_types = ["TXT"]
 	}
 	depends_on = [
 		"vinyldns_group.test_group"

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -198,11 +198,9 @@ func testAccCheckVinylDNSZoneWithACLExists(n, email string) resource.TestCheckFu
 			return fmt.Errorf("Expected Zone %s ACL rule AccessLevel to be 'Delete'; got %s", "system-test.", acl.AccessLevel)
 		}
 
-		/*
-			if acl.RecordTypes[0] != "TXT" {
-				return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", "system-test.", acl.RecordTypes[0])
-			}
-		*/
+		if acl.RecordTypes[0] != "TXT" {
+			return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", "system-test.", acl.RecordTypes[0])
+		}
 
 		return nil
 	}

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -198,9 +198,11 @@ func testAccCheckVinylDNSZoneWithACLExists(n, email string) resource.TestCheckFu
 			return fmt.Errorf("Expected Zone %s ACL rule AccessLevel to be 'Delete'; got %s", "system-test.", acl.AccessLevel)
 		}
 
-		if acl.RecordTypes[0] != "TXT" {
-			return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", "system-test.", acl.RecordTypes[0])
-		}
+		/*
+			if acl.RecordTypes[0] != "TXT" {
+				return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", "system-test.", acl.RecordTypes[0])
+			}
+		*/
 
 		return nil
 	}
@@ -211,12 +213,8 @@ func testAccVinylDNSZoneConfigBasic(email string) string {
 resource "vinyldns_group" "test_group" {
 	name = "terraformtestgroup"
 	email = "tftest@tf.com"
-	member {
-	  id = "ok"
-	}
-	admin {
-	  id = "ok"
-	}
+	member_ids = ["ok"]
+	admin_ids = ["ok"]
 }
 
 resource "vinyldns_zone" "test_zone" {
@@ -247,7 +245,6 @@ resource "vinyldns_zone" "test_zone" {
 	acl_rule {
 		access_level = "Delete"
 		group_id = "${vinyldns_group.test_group.id}"
-		record_types = ["TXT"]
 	}
 	depends_on = [
 		"vinyldns_group.test_group"

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -86,6 +86,38 @@ func TestAccVinylDNSZoneWithACL(t *testing.T) {
 	})
 }
 
+func TestAccVinylDNSZoneWithACLAndNoRecordTypes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVinylDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVinylDNSZoneConfigWithACLAndNoRecordTypes("email@foo.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVinylDNSZoneWithACLAndNoRecordTypesExists("vinyldns_zone.test_zone", "email@foo.com"),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "email@foo.com"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccVinylDNSZoneConfigWithACLAndNoRecordTypes("updated_email@foo.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVinylDNSZoneWithACLAndNoRecordTypesExists("vinyldns_zone.test_zone", "updated_email@foo.com"),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "updated_email@foo.com"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vinyldns_zone.test_zone",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccVinylDNSZoneImportStateCheck,
+			},
+		},
+	})
+}
+
 func testAccVinylDNSZoneImportStateCheck(s []*terraform.InstanceState) error {
 	if len(s) != 1 {
 		return fmt.Errorf("expected 1 state: %#v", s)
@@ -206,6 +238,47 @@ func testAccCheckVinylDNSZoneWithACLExists(n, email, recType string) resource.Te
 	}
 }
 
+func testAccCheckVinylDNSZoneWithACLAndNoRecordTypesExists(n, email string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", rs)
+		}
+		log.Printf("[INFO] testing that zone exists: %s", rs.Primary.ID)
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Zone ID is set")
+		}
+
+		client := testAccProvider.Meta().(*vinyldns.Client)
+
+		readZone, err := client.Zone(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if readZone.Name != "system-test." {
+			return fmt.Errorf("Zone %s not found", "system-test.")
+		}
+
+		if readZone.Email != email {
+			return fmt.Errorf("Zone %s with email %s not found", "system-test.", email)
+		}
+
+		acl := readZone.ACL.Rules[0]
+
+		if acl.GroupID == "" {
+			return fmt.Errorf("Zone %s ACL rule has an empty GroupID", "system-test.")
+		}
+
+		if acl.AccessLevel != "Delete" {
+			return fmt.Errorf("Expected Zone %s ACL rule AccessLevel to be 'Delete'; got %s", "system-test.", acl.AccessLevel)
+		}
+
+		return nil
+	}
+}
+
 func testAccVinylDNSZoneConfigBasic(email string) string {
 	const t = `
 resource "vinyldns_group" "test_group" {
@@ -251,4 +324,29 @@ resource "vinyldns_zone" "test_zone" {
 }`
 
 	return fmt.Sprintf(t, email, rTypes)
+}
+
+func testAccVinylDNSZoneConfigWithACLAndNoRecordTypes(email string) string {
+	const t = `
+resource "vinyldns_group" "test_group" {
+	name = "terraformtestgroup"
+	email = "tftest@tf.com"
+	member_ids = ["ok"]
+	admin_ids = ["ok"]
+}
+
+resource "vinyldns_zone" "test_zone" {
+	name = "system-test."
+	email = "%s"
+	admin_group_id = "${vinyldns_group.test_group.id}"
+	acl_rule {
+		access_level = "Delete"
+		group_id = "${vinyldns_group.test_group.id}"
+	}
+	depends_on = [
+		"vinyldns_group.test_group"
+	]
+}`
+
+	return fmt.Sprintf(t, email)
 }

--- a/website/docs/r/zone.html.md
+++ b/website/docs/r/zone.html.md
@@ -74,3 +74,7 @@ The following attributes are exported:
 * `status` - The zone status.
 
 * `created` - The time when the zone was first created.
+
+* `updated` - The time when the zone was last updated.
+
+* `latest_sync` - The time when the zone was synced.


### PR DESCRIPTION
This seeks to address issue #15 by adding some zone resource features:

* add `acl_rule` attribute through which ACL rules can be specified
* adds `latest_sync` computed property on zones
* adds `updated` computed property on zones