### PR TITLE
Exercise connections, etc. in zone tests

### DIFF
--- a/vinyldns/resource_group_test.go
+++ b/vinyldns/resource_group_test.go
@@ -34,6 +34,10 @@ func TestAccVinylDNSGroupBasic(t *testing.T) {
 					testAccCheckVinylDNSGroupExists("vinyldns_group.test_group", "description"),
 					resource.TestCheckResourceAttr("vinyldns_group.test_group", "name", "terraformtestgroup"),
 					resource.TestCheckResourceAttr("vinyldns_group.test_group", "description", "description"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "member_ids.#", "1"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "member_ids.2044517703", "ok"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "admin_ids.#", "1"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "admin_ids.2044517703", "ok"),
 				),
 			},
 			resource.TestStep{
@@ -42,6 +46,10 @@ func TestAccVinylDNSGroupBasic(t *testing.T) {
 					testAccCheckVinylDNSGroupExists("vinyldns_group.test_group", "updated description"),
 					resource.TestCheckResourceAttr("vinyldns_group.test_group", "name", "terraformtestgroup"),
 					resource.TestCheckResourceAttr("vinyldns_group.test_group", "description", "updated description"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "member_ids.#", "1"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "member_ids.2044517703", "ok"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "admin_ids.#", "1"),
+					resource.TestCheckResourceAttr("vinyldns_group.test_group", "admin_ids.2044517703", "ok"),
 				),
 			},
 			resource.TestStep{

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -43,6 +43,7 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "name", "cname-terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "type", "CNAME"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "ttl", "6000"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "record_cname", "terraformtestrecordset.system-test."),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "name", "txt-terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "type", "TXT"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "ttl", "6000"),

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -36,6 +36,10 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "name", "terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "type", "A"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "ttl", "6000"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "record_addresses.#", "2"),
+					// NOTE: the following will fail if ever the record_addresses values change, as these indexes are hashes of 127.0.0.2 and 127.0.0.1, respectively
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "record_addresses.1321121298", "127.0.0.2"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_a_record_set", "record_addresses.3619153832", "127.0.0.1"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "name", "cname-terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "type", "CNAME"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_cname_record_set", "ttl", "6000"),
@@ -333,7 +337,7 @@ resource "vinyldns_record_set" "test_a_record_set" {
 	owner_group_id = "${vinyldns_group.test_group.id}"
 	type = "A"
 	ttl = 6000
-	record_addresses = ["127.0.0.1", "127.0.0.1"]
+	record_addresses = ["127.0.0.1", "127.0.0.2"]
 	depends_on = [
 		"vinyldns_zone.test_zone"
 	]

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -42,6 +42,9 @@ func TestAccVinylDNSRecordSetBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "name", "txt-terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "type", "TXT"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "ttl", "6000"),
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "record_texts.#", "1"),
+					// NOTE: the following will fail if ever record_texts is something other than ["some-text"], as 3073014027 is a hash of some-text
+					resource.TestCheckResourceAttr("vinyldns_record_set.test_txt_record_set", "record_texts.3073014027", "some-text"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "name", "ns-terraformtestrecordset"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "type", "NS"),
 					resource.TestCheckResourceAttr("vinyldns_record_set.test_ns_record_set", "ttl", "6000"),
@@ -352,7 +355,7 @@ resource "vinyldns_record_set" "test_txt_record_set" {
 	zone_id = "${vinyldns_zone.test_zone.id}"
 	type = "TXT"
 	ttl = 6000
-	record_texts = ["Lorem ipsum and all that jazz"]
+	record_texts = ["some-text"]
 	depends_on = [
 		"vinyldns_zone.test_zone"
 	]

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -273,7 +273,7 @@ func testAccVinylDNSZoneWithACLImportStateCheck(s []*terraform.InstanceState) er
 
 	accessLev := rs.Attributes[fmt.Sprintf("acl_rule.%s.access_level", zACLRuleUpdatedHash)]
 	if accessLev != "Delete" {
-		return fmt.Errorf("expected acl_rule access_level attribute to have value; got %s from state: %s", accessLev, rs.Attributes)
+		return fmt.Errorf("expected acl_rule access_level attribute to be 'Delete'; got %s from state: %s", accessLev, rs.Attributes)
 	}
 
 	recTypes := rs.Attributes[fmt.Sprintf("acl_rule.%s.record_types.%s", zACLRuleUpdatedHash, zACLRuleRecordTypesUpdatedHash)]

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -23,13 +23,17 @@ import (
 )
 
 const (
-	zName                          = "system-test."
-	zEmail                         = "email@foo.com"
-	zEmailUpdated                  = "updated_email@foo.com"
-	zConName                       = "vinyldns."
-	zConKey                        = "nzisn+4G2ldMn0q1CV3vsg=="
-	zConKeyName                    = "vinyldns."
-	zConPrimaryServer              = "vinyldns-bind9"
+	zName             = "system-test."
+	zEmail            = "email@foo.com"
+	zEmailUpdated     = "updated_email@foo.com"
+	zConName          = "vinyldns."
+	zConKey           = "nzisn+4G2ldMn0q1CV3vsg=="
+	zConKeyName       = "vinyldns."
+	zConPrimaryServer = "vinyldns-bind9"
+	// NOTE: If ever the test config HCL is changed, these zACLRule*Hash var
+	// values will change as well, as TypeSets are stored in state with an
+	// index value calculated by the hash of the attributes of the set.
+	// https://www.terraform.io/docs/extend/schemas/schema-types.html
 	zACLRuleHash                   = "4011566075"
 	zACLRuleUpdatedHash            = "4195916832"
 	zACLRuleRecordTypesHash        = "1750616469"

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -32,7 +32,7 @@ const (
 	zConPrimaryServer              = "vinyldns-bind9"
 	zACLRuleHash                   = "4011566075"
 	zACLRuleUpdatedHash            = "4195916832"
-	zACLRuleRecordTypesHash        = ""
+	zACLRuleRecordTypesHash        = "1750616469"
 	zACLRuleRecordTypesUpdatedHash = "430998943"
 )
 
@@ -82,6 +82,7 @@ func TestAccVinylDNSZoneWithACL(t *testing.T) {
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmail),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", fmt.Sprintf("acl_rule.%s.access_level", zACLRuleHash), "Delete"),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", fmt.Sprintf("acl_rule.%s.user_id", zACLRuleHash), "ok"),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", fmt.Sprintf("acl_rule.%s.record_types.%s", zACLRuleHash, zACLRuleRecordTypesHash), "TXT"),
 				),
 			},
 			resource.TestStep{
@@ -236,12 +237,12 @@ func testAccVinylDNSZoneWithACLImportStateCheck(s []*terraform.InstanceState) er
 
 	accessLev := rs.Attributes[fmt.Sprintf("acl_rule.%s.access_level", zACLRuleUpdatedHash)]
 	if accessLev != "Delete" {
-		return fmt.Errorf("expected acl_rule access_level attribute to have value; got %s", rs.Attributes)
+		return fmt.Errorf("expected acl_rule access_level attribute to have value; got %s from state: %s", accessLev, rs.Attributes)
 	}
 
 	recTypes := rs.Attributes[fmt.Sprintf("acl_rule.%s.record_types.%s", zACLRuleUpdatedHash, zACLRuleRecordTypesUpdatedHash)]
 	if recTypes != "A" {
-		return fmt.Errorf("expected acl_rule record_types attribute to have value; got %s", recTypes)
+		return fmt.Errorf("expected acl_rule record_types attribute to be 'A'; got %s from state: %s", recTypes, rs.Attributes)
 	}
 
 	return nil

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -179,6 +179,10 @@ func testAccVinylDNSZoneImportStateCheck(s []*terraform.InstanceState) error {
 		return fmt.Errorf("expected email attribute to be %s, received %s", expEmail, email)
 	}
 
+	if rs.Attributes["admin_group_id"] == "" {
+		return fmt.Errorf("expected admin_group_id attribute to have value")
+	}
+
 	return nil
 }
 

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -22,6 +22,16 @@ import (
 	"github.com/vinyldns/go-vinyldns/vinyldns"
 )
 
+const (
+	zName             = "system-test."
+	zEmail            = "email@foo.com"
+	zEmailUpdated     = "updated_email@foo.com"
+	zConName          = "vinyldns."
+	zConKey           = "nzisn+4G2ldMn0q1CV3vsg=="
+	zConKeyName       = "vinyldns."
+	zConPrimaryServer = "vinyldns-bind9"
+)
+
 func TestAccVinylDNSZoneBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,19 +39,19 @@ func TestAccVinylDNSZoneBasic(t *testing.T) {
 		CheckDestroy: testAccVinylDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigBasic("email@foo.com"),
+				Config: testAccVinylDNSZoneConfigBasic(zEmail),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneBasicExists("vinyldns_zone.test_zone", "email@foo.com"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "email@foo.com"),
+					testAccCheckVinylDNSZoneBasicExists("vinyldns_zone.test_zone", zEmail),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmail),
 				),
 			},
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigBasic("updated_email@foo.com"),
+				Config: testAccVinylDNSZoneConfigBasic(zEmailUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneBasicExists("vinyldns_zone.test_zone", "updated_email@foo.com"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "updated_email@foo.com"),
+					testAccCheckVinylDNSZoneBasicExists("vinyldns_zone.test_zone", zEmailUpdated),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmailUpdated),
 				),
 			},
 			resource.TestStep{
@@ -61,19 +71,19 @@ func TestAccVinylDNSZoneWithACL(t *testing.T) {
 		CheckDestroy: testAccVinylDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigWithACL("email@foo.com", "TXT"),
+				Config: testAccVinylDNSZoneConfigWithACL(zEmail, "TXT"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneWithACLExists("vinyldns_zone.test_zone", "email@foo.com", "TXT"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "email@foo.com"),
+					testAccCheckVinylDNSZoneWithACLExists("vinyldns_zone.test_zone", zEmail, "TXT"),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmail),
 				),
 			},
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigWithACL("updated_email@foo.com", "A"),
+				Config: testAccVinylDNSZoneConfigWithACL(zEmailUpdated, "A"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneWithACLExists("vinyldns_zone.test_zone", "updated_email@foo.com", "A"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "updated_email@foo.com"),
+					testAccCheckVinylDNSZoneWithACLExists("vinyldns_zone.test_zone", zEmailUpdated, "A"),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmailUpdated),
 				),
 			},
 			resource.TestStep{
@@ -93,19 +103,19 @@ func TestAccVinylDNSZoneWithConnection(t *testing.T) {
 		CheckDestroy: testAccVinylDNSZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigWithConnection("email@foo.com"),
+				Config: testAccVinylDNSZoneConfigWithConnection(zEmail),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneWithConnectionExists("vinyldns_zone.test_zone", "email@foo.com"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "email@foo.com"),
+					testAccCheckVinylDNSZoneWithConnectionExists("vinyldns_zone.test_zone", zEmail),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmail),
 				),
 			},
 			resource.TestStep{
-				Config: testAccVinylDNSZoneConfigWithConnection("updated_email@foo.com"),
+				Config: testAccVinylDNSZoneConfigWithConnection(zEmailUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVinylDNSZoneWithConnectionExists("vinyldns_zone.test_zone", "updated_email@foo.com"),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", "system-test."),
-					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", "updated_email@foo.com"),
+					testAccCheckVinylDNSZoneWithConnectionExists("vinyldns_zone.test_zone", zEmailUpdated),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmailUpdated),
 				),
 			},
 			resource.TestStep{
@@ -125,13 +135,13 @@ func testAccVinylDNSZoneImportStateCheck(s []*terraform.InstanceState) error {
 
 	rs := s[0]
 
-	expName := "system-test."
+	expName := zName
 	name := rs.Attributes["name"]
-	if name != expName {
+	if name != zName {
 		return fmt.Errorf("expected name attribute to be %s, received %s", expName, name)
 	}
 
-	expEmail := "updated_email@foo.com"
+	expEmail := zEmailUpdated
 	email := rs.Attributes["email"]
 	if email != expEmail {
 		return fmt.Errorf("expected email attribute to be %s, received %s", expEmail, email)
@@ -181,12 +191,12 @@ func testAccCheckVinylDNSZoneBasicExists(n, email string) resource.TestCheckFunc
 			return err
 		}
 
-		if readZone.Name != "system-test." {
-			return fmt.Errorf("Zone %s not found", "system-test.")
+		if readZone.Name != zName {
+			return fmt.Errorf("Zone %s not found", zName)
 		}
 
 		if readZone.Email != email {
-			return fmt.Errorf("Zone %s with email %s not found", "system-test.", email)
+			return fmt.Errorf("Zone %s with email %s not found", zName, email)
 		}
 
 		return nil
@@ -212,26 +222,26 @@ func testAccCheckVinylDNSZoneWithACLExists(n, email, recType string) resource.Te
 			return err
 		}
 
-		if readZone.Name != "system-test." {
-			return fmt.Errorf("Zone %s not found", "system-test.")
+		if readZone.Name != zName {
+			return fmt.Errorf("Zone %s not found", zName)
 		}
 
 		if readZone.Email != email {
-			return fmt.Errorf("Zone %s with email %s not found", "system-test.", email)
+			return fmt.Errorf("Zone %s with email %s not found", zName, email)
 		}
 
 		acl := readZone.ACL.Rules[0]
 
 		if acl.GroupID == "" {
-			return fmt.Errorf("Zone %s ACL rule has an empty GroupID", "system-test.")
+			return fmt.Errorf("Zone %s ACL rule has an empty GroupID", zName)
 		}
 
 		if acl.AccessLevel != "Delete" {
-			return fmt.Errorf("Expected Zone %s ACL rule AccessLevel to be 'Delete'; got %s", "system-test.", acl.AccessLevel)
+			return fmt.Errorf("Expected Zone %s ACL rule AccessLevel to be 'Delete'; got %s", zName, acl.AccessLevel)
 		}
 
 		if acl.RecordTypes[0] != recType {
-			return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", "system-test.", acl.RecordTypes[0])
+			return fmt.Errorf("Expected Zone %s ACL rule RecordTypes to include 'TXT'; got %s", zName, acl.RecordTypes[0])
 		}
 
 		return nil
@@ -257,28 +267,28 @@ func testAccCheckVinylDNSZoneWithConnectionExists(n, email string) resource.Test
 			return err
 		}
 
-		if readZone.Name != "system-test." {
-			return fmt.Errorf("Zone %s not found", "system-test.")
+		if readZone.Name != zName {
+			return fmt.Errorf("Zone %s not found", zName)
 		}
 
 		if readZone.Email != email {
-			return fmt.Errorf("Zone %s with email %s not found", "system-test.", email)
+			return fmt.Errorf("Zone %s with email %s not found", zName, email)
 		}
 
 		if readZone.Connection.Name != zConName {
-			return fmt.Errorf("Zone %s with connection name %s not found", "system-test.", zConName)
+			return fmt.Errorf("Zone %s with connection name %s not found", zName, zConName)
 		}
 
 		if readZone.Connection.KeyName != zConKeyName {
-			return fmt.Errorf("Zone %s with connection key name %s not found", "system-test.", zConKeyName)
+			return fmt.Errorf("Zone %s with connection key name %s not found", zName, zConKeyName)
 		}
 
 		if readZone.Connection.Key != zConKey {
-			return fmt.Errorf("Zone %s with connection key %s not found", "system-test.", zConKey)
+			return fmt.Errorf("Zone %s with connection key %s not found", zName, zConKey)
 		}
 
 		if readZone.Connection.PrimaryServer != zConPrimaryServer {
-			return fmt.Errorf("Zone %s with connection primary server %s not found", "system-test.", zConPrimaryServer)
+			return fmt.Errorf("Zone %s with connection primary server %s not found", zName, zConPrimaryServer)
 		}
 
 		return nil
@@ -316,7 +326,7 @@ resource "vinyldns_group" "test_group" {
 }
 
 resource "vinyldns_zone" "test_zone" {
-	name = "system-test."
+	name = "%s"
 	email = "%s"
 	admin_group_id = "${vinyldns_group.test_group.id}"
 	acl_rule {
@@ -329,15 +339,8 @@ resource "vinyldns_zone" "test_zone" {
 	]
 }`
 
-	return fmt.Sprintf(t, email, rTypes)
+	return fmt.Sprintf(t, zName, email, rTypes)
 }
-
-const (
-	zConName          = "vinyldns."
-	zConKey           = "nzisn+4G2ldMn0q1CV3vsg=="
-	zConKeyName       = "vinyldns."
-	zConPrimaryServer = "vinyldns-bind9"
-)
 
 func testAccVinylDNSZoneConfigWithConnection(email string) string {
 	const t = `
@@ -349,7 +352,7 @@ resource "vinyldns_group" "test_group" {
 }
 
 resource "vinyldns_zone" "test_zone" {
-	name = "system-test."
+	name = "%s"
 	email = "%s"
 	admin_group_id = "${vinyldns_group.test_group.id}"
 	zone_connection {
@@ -363,5 +366,5 @@ resource "vinyldns_zone" "test_zone" {
 	]
 }`
 
-	return fmt.Sprintf(t, email, zConName, zConKey, zConKeyName, zConPrimaryServer)
+	return fmt.Sprintf(t, zName, email, zConName, zConKey, zConKeyName, zConPrimaryServer)
 }

--- a/vinyldns/resource_zone_test.go
+++ b/vinyldns/resource_zone_test.go
@@ -76,6 +76,8 @@ func TestAccVinylDNSZoneWithACL(t *testing.T) {
 					testAccCheckVinylDNSZoneWithACLExists("vinyldns_zone.test_zone", zEmail, "TXT"),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "name", zName),
 					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "email", zEmail),
+					// NOTE: why does this seemingly receive a different index with each test execution?
+					resource.TestCheckResourceAttr("vinyldns_zone.test_zone", "acl_rule.1878097405.access_level", "Delete"),
 				),
 			},
 			resource.TestStep{
@@ -225,20 +227,18 @@ func testAccVinylDNSZoneWithACLImportStateCheck(s []*terraform.InstanceState) er
 		return fmt.Errorf("expected admin_group_id attribute to have value")
 	}
 
-	//TODO: why does acl_rule get a different index each time?
+	// NOTE: why does acl_rule get a different index each time?
 	// According to Terraform docs, "items are stored in state with an index value calculated by the hash of the attributes of the set."
 	// https://www.terraform.io/docs/extend/schemas/schema-types.html
-	/*
-		accessLev := rs.Attributes["acl_rule.1878097405.access_level"]
-		if accessLev != "Delete" {
-			return fmt.Errorf("expected acl_rule attribute to have value; got %s", accessLev)
-		}
+	accessLev := rs.Attributes["acl_rule.1878097405.access_level"]
+	if accessLev != "Delete" {
+		return fmt.Errorf("expected acl_rule attribute to have value; got %s", accessLev)
+	}
 
-			recTypes := rs.Attributes["acl_rule.0.record_types.430998943"]
-			if recTypes != "A" {
-				return fmt.Errorf("expected acl_rule record_types attribute to have value; got %s", recTypes)
-			}
-	*/
+	recTypes := rs.Attributes["acl_rule.0.record_types.430998943"]
+	if recTypes != "A" {
+		return fmt.Errorf("expected acl_rule record_types attribute to have value; got %s", recTypes)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR seeks to exercise more functionality in the zone resource tests towards the goal of more robust testing and addressing issue #21.