### PR TITLE
Upgrade funcs

### DIFF
--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -24,6 +24,7 @@ func resourceVinylDNSRecordSet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		MigrateState: resourceVinylDNSRecordSetMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/vinyldns/resource_record_set_migrate_state.go
+++ b/vinyldns/resource_record_set_migrate_state.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -37,8 +38,18 @@ func migrateVinylDNSRecordSetStateV0toV1(is *terraform.InstanceState) (*terrafor
 	}
 
 	log.Printf("[DEBUG] Attributes before migration for record set %s: %#v", is.ID, is.Attributes)
+
 	newID := is.Attributes["zone_id"] + ":" + is.ID
 	is.ID = newID
+
+	rText := is.Attributes["record_text"]
+	if rText != "" {
+		h := schema.HashString(rText)
+		is.Attributes["record_texts.#"] = "1"
+		is.Attributes[fmt.Sprintf("record_texts.%v", h)] = rText
+	}
+
 	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, newID)
+
 	return is, nil
 }

--- a/vinyldns/resource_record_set_migrate_state.go
+++ b/vinyldns/resource_record_set_migrate_state.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceVinylDNSRecordSetMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found VinylDNS RecordSet State v0; migrating to v1")
+		return migrateVinylDNSRecordSetStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateVinylDNSRecordSetStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration for record set %s: %#v", is.ID, is.Attributes)
+	newID := is.Attributes["zone_id"] + ":" + is.ID
+	is.ID = newID
+	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, newID)
+	return is, nil
+}

--- a/vinyldns/resource_record_set_migrate_state_test.go
+++ b/vinyldns/resource_record_set_migrate_state_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestVinylDNSRecordSetMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_0": {
+			StateVersion: 0,
+			ID:           "id",
+			Attributes: map[string]string{
+				"zone_id": "zone-id",
+			},
+			Expected: "zone-id:id",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceVinylDNSRecordSetMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.ID != tc.Expected {
+			t.Fatalf("bad VinylDNS RecordSet Migrate: %s\n\n expected: %s", is.ID, tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
This seeks to address issue #19 by migrating state on behalf of users upgrading from pre-0.9 `terraform-provider-vinyldns` for those resources whose state schema has changed, in particular `record_set.record_text`, which is now `record_set.record_texts`.

While there are far more 0.8 -> 0.9 `terraform-provider-vinyldns` resource schema changes than just `record_set.record_text` -> `record_set.record_texts`, it is my believe that the other 0.8, now-deprecated resource schema attributes were not properly saved in 0.8 `terraform-provider-vinyldns` state anyways and thus no migrator funcs are warranted.