### PR TITLE
remove the 'release.' prefix from release assets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -83,7 +83,7 @@ release: package
 		--target "$(shell git rev-parse --abbrev-ref HEAD)" \
 		--tag "${VERSION}" \
 		--name "${VERSION}"
-	ls release/*.tgz | xargs -I FILE github-release upload \
+	cd release && ls *.tgz | xargs -I FILE github-release upload \
 		--user vinyldns \
 		--repo "${NAME}" \
 		--tag "${VERSION}" \


### PR DESCRIPTION
Currently, the individual compiled assets associated with a release
are uploaded to github.com with a 'release.' prefix. For example:

https://github.com/vinyldns/terraform-provider-vinyldns/releases/tag/0.9.4

This seeks to ensure future release assets are uploaded without the 'release' prefix.