### PR TITLE
add custom useragent in go-vinyldns client

### DIFF
--- a/vinyldns/provider.go
+++ b/vinyldns/provider.go
@@ -77,6 +77,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AccessKey: d.Get("access_key").(string),
 		SecretKey: d.Get("secret_key").(string),
 		Host:      d.Get("host").(string),
+		UserAgent: GetUserAgent(),
 	}
 
 	return vinyldns.NewClient(config), nil

--- a/vinyldns/provider_version.go
+++ b/vinyldns/provider_version.go
@@ -10,18 +10,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package vinyldns
 
-import (
-	"github.com/hashicorp/terraform/plugin"
-	"github.com/vinyldns/terraform-provider-vinyldns/vinyldns"
-)
+import "strings"
 
 var version string
 
-func main() {
-	vinyldns.SetVersion(version)
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: vinyldns.Provider,
-	})
+// SetVersion allows to set current provider version.
+func SetVersion(ver string) {
+	version = ver
+}
+
+// GetUserAgent returns UserAgent for provider based
+// on currently set version.
+func GetUserAgent() string {
+	if version == "" {
+		return "terraform-provider-vinyldns"
+	}
+
+	return strings.Join([]string{
+		"terraform-provider-vinyldns",
+		version,
+	}, "/")
 }

--- a/vinyldns/provider_version_test.go
+++ b/vinyldns/provider_version_test.go
@@ -1,0 +1,38 @@
+package vinyldns
+
+import "testing"
+
+func TestGetUserAgent(t *testing.T) {
+	testCases := []struct {
+		name       string
+		version    string
+		expectedUA string
+	}{
+		{
+			name:       "empty version",
+			version:    "",
+			expectedUA: "terraform-provider-vinyldns",
+		},
+		{
+			name:       "version set",
+			version:    "0.9.3",
+			expectedUA: "terraform-provider-vinyldns/0.9.3",
+		},
+		{
+			name:       "version set",
+			version:    "1.0.1-dev",
+			expectedUA: "terraform-provider-vinyldns/1.0.1-dev",
+		},
+	}
+
+	for _, testCase := range testCases {
+		SetVersion(testCase.version)
+
+		t.Run(testCase.name, func(t *testing.T) {
+			useragent := GetUserAgent()
+			if useragent != testCase.expectedUA {
+				t.Fatalf("expected user-agent to be '%s', got '%s'", testCase.expectedUA, useragent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Change

Go client for VinylDNS allows to set custom UserAgent, I modified providers `ConfigureFunc` in this change to create client with such UserAgent. At build stage (using makefile) there is `-ldflags "-X main.version=${VERSION}"` passed to the compiler which sets `version` variable in `main.go` file. Afterwards version is used to generate `terraform-provider-vinyldns/<version>` like UserAgent. Additionaly if given version is empty, generated UserAgent will be equal to `terraform-provider-vinyldns` (no version postfix).

## Why Should This Be In The Package?

It satisfies issue #59 

## Benefits

Custom UserAgent allows to easy search and aggregate.

## Possible Drawbacks

If there are some services/metrics that are filtering/basing on UserAgent header, they will need a change.

## Verification Process

I created some unit tests for UserAgent generator. Unfortunately I don't know how to test if version variable was set on build time. If everything will work as expected, UserAgent will be equal to `terraform-provider-vinyldns/<version>`. In worst case scenario UserAgent would be `terraform-provider-vinyldns`
