### PR TITLE
Fail gracefully when an incorrect separator is used

### DIFF
--- a/vinyldns/helpers.go
+++ b/vinyldns/helpers.go
@@ -13,6 +13,7 @@ limitations under the License.
 package vinyldns
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -29,10 +30,14 @@ func stringSetToStringSlice(stringSet *schema.Set) []string {
 	return ret
 }
 
-func parseTwoPartID(id string) (string, string) {
+func parseTwoPartID(id string) (string, string, error) {
 	parts := strings.Split(id, ":")
 
-	return parts[0], parts[1]
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected zone_id:record_set_id", id)
+	}
+
+	return parts[0], parts[1], nil
 }
 
 // vinyldns responds 400 to IPv6 addresses represented within `[` `]`

--- a/vinyldns/helpers_test.go
+++ b/vinyldns/helpers_test.go
@@ -17,12 +17,32 @@ import (
 )
 
 func Test_parseTwoPartID(t *testing.T) {
-	one, two := parseTwoPartID("123:456")
+	one, two, err := parseTwoPartID("123:456")
 	if one != "123" {
 		t.Fatalf("expected parseTwoPartID to return ID part 1 as '123'")
 	}
 	if two != "456" {
 		t.Fatalf("expected parseTwoPartID to return ID part 2 as '456'")
+	}
+
+	if err != nil {
+		t.Fatalf("Did not expect an error but one was raised. Error: %s", err)
+	}
+}
+
+func Test_parseTwoPartIDIncorrectSeparator(t *testing.T) {
+	one, two, err := parseTwoPartID("123.456")
+
+	if one != "" {
+		t.Fatalf("expected parseTwoPartID to return ID part 1 as ''")
+	}
+
+	if two != "" {
+		t.Fatalf("expected parseTwoPartID to return ID part 2 as ''")
+	}
+
+	if err == nil {
+		t.Fatalf("Expected an error but one was not raised")
 	}
 }
 

--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -118,7 +118,10 @@ func resourceVinylDNSRecordSetCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) error {
-	zID, rsID := parseTwoPartID(d.Id())
+	zID, rsID, err := parseTwoPartID(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Reading vinyldns record set %s in zone %s", rsID, zID)
 	rs, err := meta.(*vinyldns.Client).RecordSet(zID, rsID)
 	if err != nil {
@@ -208,7 +211,10 @@ func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceVinylDNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	zID, rsID := parseTwoPartID(d.Id())
+	zID, rsID, err := parseTwoPartID(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Updating vinyldns record set %s in zone %s", rsID, zID)
 	records, err := records(d)
 	if err != nil {
@@ -236,7 +242,10 @@ func resourceVinylDNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceVinylDNSRecordSetDelete(d *schema.ResourceData, meta interface{}) error {
-	zID, rsID := parseTwoPartID(d.Id())
+	zID, rsID, err := parseTwoPartID(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Deleting vinyldns record set %s in zone %s", rsID, zID)
 
 	deleted, err := meta.(*vinyldns.Client).RecordSetDelete(d.Get("zone_id").(string), rsID)
@@ -374,7 +383,10 @@ func waitUntilRecordSetDeployed(d *schema.ResourceData, meta interface{}, change
 
 func recordSetStateRefreshFunc(d *schema.ResourceData, meta interface{}, changeID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		_, rsID := parseTwoPartID(d.Id())
+		_, rsID, err := parseTwoPartID(d.Id())
+		if err != nil {
+			return nil, "", err
+		}
 		log.Printf("[INFO] waiting for %v Complete status", d.Id())
 		rsc, err := meta.(*vinyldns.Client).RecordSetChange(d.Get("zone_id").(string), rsID, changeID)
 		if err != nil {

--- a/vinyldns/resource_record_set_test.go
+++ b/vinyldns/resource_record_set_test.go
@@ -278,10 +278,13 @@ func testAccVinylDNSRecordSetDestroy(s *terraform.State) error {
 		if rs.Type != "vinyldns_record_set" {
 			continue
 		}
-		zID, rsID := parseTwoPartID(rs.Primary.ID)
+		zID, rsID, err := parseTwoPartID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		// Try to find the record set
-		_, err := client.RecordSet(zID, rsID)
+		_, err = client.RecordSet(zID, rsID)
 		if err == nil {
 			return fmt.Errorf("RecordSet %s still exists in zone %s", rsID, zID)
 		}
@@ -302,7 +305,10 @@ func testAccCheckVinylDNSRecordSetExists(n string) resource.TestCheckFunc {
 		}
 
 		client := testAccProvider.Meta().(*vinyldns.Client)
-		zID, rsID := parseTwoPartID(rs.Primary.ID)
+		zID, rsID, err := parseTwoPartID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 		readRs, err := client.RecordSet(zID, rsID)
 		if err != nil {
 			return err
@@ -327,7 +333,10 @@ func testRecordInZone(n string, s *terraform.State, expectedZone string) error {
 	}
 
 	client := testAccProvider.Meta().(*vinyldns.Client)
-	zID, rsID := parseTwoPartID(rs.Primary.ID)
+	zID, rsID, err := parseTwoPartID(rs.Primary.ID)
+	if err != nil {
+		return err
+	}
 	readRs, err := client.RecordSet(zID, rsID)
 	if err != nil {
 		return err


### PR DESCRIPTION

## Description of the Change

RecordSet ids are expected to be in the format of zone_id:record_set_id.
If `:` is not found, inform the user with an error instead of panicking.


## Why Should This Be In The Package?

Better user experience 

## Benefits

Better user experience

## Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

Ran terraform input with an incorrect format
```
Error: Unexpected ID format ("1111.2222"). Expected zone_id:reco
rd_set_id
```

## Applicable Issues (Optional)

#72 
