### PR TITLE
add group data source

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -1,13 +1,11 @@
-resource "vinyldns_group" "test_group" {
-  name       = "terraform-provider-test-group"
-  member_ids = ["123"]
-  admin_ids  = ["123"]
+data "vinyldns_group" "test_group" {
+  id = "testgroupid"
 }
 
 resource "vinyldns_zone" "test_zone" {
   name           = "system-test."
   email          = "foo@bar.com"
-  admin_group_id = "${vinyldns_group.test_group.id}"
+  admin_group_id = "${data.vinyldns_group.test_group.id}"
 
   zone_connection {
     name           = "vinyldns."

--- a/vinyldns/data_source_group.go
+++ b/vinyldns/data_source_group.go
@@ -1,0 +1,55 @@
+package vinyldns
+
+import (
+  "fmt"
+  "log"
+
+  "github.com/hashicorp/terraform/helper/schema"
+  "github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func dataSourceVinylDNSGroup() *schema.Resource {
+  return &schema.Resource{
+    Read: dataSourceVinylDNSGroupRead,
+
+    Schema: map[string]*schema.Schema{
+      "id": {
+        Type: schema.TypeString,
+        Optional: true,
+      },
+      "name": {
+        Type: schema.TypeString,
+        Computed: true,
+      },
+      "email": {
+        Type: schema.TypeString,
+        Computed: true,
+      },
+    },
+  }
+}
+
+func dataSourceVinylDNSGroupRead(d *schema.ResourceData, meta interface{}) error {
+  var id string
+  if i, ok := d.GetOk("id"); ok {
+    id = i.(string)
+  }
+
+  if id == "" {
+    return fmt.Errorf("%s must be provided", "id")
+  }
+
+  log.Printf("[INFO] Reading VinylDNS group %s", id)
+
+  g, err := meta.(*vinyldns.Client).Group(id)
+  if err != nil {
+    return err
+  }
+
+  d.SetId(g.ID)
+
+  d.Set("name", g.Name)
+  d.Set("email", g.Email)
+
+  return nil
+}

--- a/vinyldns/data_source_group_test.go
+++ b/vinyldns/data_source_group_test.go
@@ -1,0 +1,34 @@
+package vinyldns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccVinylDNSGroupDataSource_basic(t *testing.T) {
+	id := "global-acl-group-id"
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+        Config: testAccCheckVinylDNSGroupDataSourceConfig(id),
+				Check: resource.ComposeAggregateTestCheckFunc(
+          resource.TestCheckResourceAttrSet("data.vinyldns_group.test", "id"),
+					resource.TestCheckResourceAttr("data.vinyldns_group.test", "id", id),
+					resource.TestCheckResourceAttr("data.vinyldns_group.test", "name", "globalACLGroup"),
+					resource.TestCheckResourceAttr("data.vinyldns_group.test", "email", "email"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVinylDNSGroupDataSourceConfig(id string) string {
+	return fmt.Sprintf(`
+data "vinyldns_group" "test" {
+	id = "%s"
+}
+`, id)
+}

--- a/vinyldns/provider.go
+++ b/vinyldns/provider.go
@@ -49,7 +49,9 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"vinyldns_zone": dataSourceVinylDNSZone(),
+      "vinyldns_group": dataSourceVinylDNSGroup(),
 		},
+
 
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
## Description of the Change

Added a Group data source so users of this provider can work with preexisting VinylDNS groups.

## Why Should This Be In The Package?

For users who have been working with VinylDNS prior to using the terraform provider they will already be a part of the groups they intend to use to manage zones and records.

## Benefits

Users don't have to use the Groups resource which requires them to know the exact state of their current groups, including member and admin IDs.

## Possible Drawbacks

Can't think of any :)

## Verification Process

I updated the example.tf to use a group data source instead of a resource. Tested that locally. I also wrote an acceptance test using an ID for a group that should exist in the local VinylDNS database. 

For the acceptance test  I tried creating a group resource and then using a function to find the group ID of that resource, but when i ran the tests I found the function was running before the new group was created, so no group matching the given group name was found.

## Applicable Issues (Optional)

group data source for #9 
