### PR TITLE
Fix IPv6 Idempotency

### DIFF
--- a/vinyldns/resource_record_set.go
+++ b/vinyldns/resource_record_set.go
@@ -53,7 +53,7 @@ func resourceVinylDNSRecordSet() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set: func(v interface{}) int {
-					return hashcode.String(v.(string))
+					return hashcode.String(removeBrackets(v.(string)))
 				},
 			},
 			"record_texts": &schema.Schema{
@@ -200,7 +200,7 @@ func resourceVinylDNSRecordSetRead(d *schema.ResourceData, meta interface{}) err
 
 	recs := make([]interface{}, 0, len(rs.Records))
 	for _, r := range rs.Records {
-		recs = append(recs, r.Address)
+		recs = append(recs, removeBrackets(r.Address))
 	}
 
 	if err := d.Set("record_addresses", schema.NewSet(schema.HashString, recs)); err != nil {


### PR DESCRIPTION
This addresses inconsistency with if ipv6 addresses from the vinyldns api have square brackets or not.

## Description of the Change

<!--

We should be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

## Why Should This Be In The Package?

<!-- Explain why this functionality should be in the package -->

## Benefits

<!-- What benefits will be realized by the code change? -->
This enables you to run terraform plan to know if there's work to do.

## Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None that I can foresee.

## Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I compiled this PR and transplanted it into my reproduce case leveraging TF11 and this fixed it.

## Applicable Issues (Optional)

<!-- Enter any applicable Issues here -->
Fixes #94 