### PR TITLE
Allow Release Script to be Run Manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently the script only runs when a new tag is pushed. This change will let the script be run on-demand from the GUI.