### PR TITLE
Add VinylDNS data sources

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,9 @@
 - Data Sources
 
+  - [vinyldns_group](data-sources/group.md)
+  - [vinyldns_zones](data-sources/zones.md)
+  - [vinyldns_record_sets](data-sources/record_sets.md)
+  - [vinyldns_backend_ids](data-sources/backend_ids.md)
   - [vinyldns_zone](data-sources/zone.md)
 
 - Resources

--- a/docs/data-sources/backend_ids.md
+++ b/docs/data-sources/backend_ids.md
@@ -1,0 +1,13 @@
+# vinyldns_backend_ids
+
+Use this data source to retrieve the list of configured backend IDs.
+
+## Example Usage
+
+```hcl
+data "vinyldns_backend_ids" "all" {}
+```
+
+## Attributes Reference
+
+* `backend_ids` - List of backend IDs.

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -1,0 +1,23 @@
+# vinyldns_group
+
+Use this data source to retrieve group details by name.
+
+## Example Usage
+
+```hcl
+data "vinyldns_group" "admins" {
+  name = "my-admins"
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) The name of the group.
+
+## Attributes Reference
+
+* `id` - The ID of the group.
+* `email` - The email associated with the group.
+* `description` - The group description.
+* `member_ids` - The member user IDs.
+* `admin_ids` - The admin user IDs.

--- a/docs/data-sources/record_sets.md
+++ b/docs/data-sources/record_sets.md
@@ -1,0 +1,28 @@
+# vinyldns_record_sets
+
+Use this data source to list record sets for a zone, optionally filtered by name.
+
+## Example Usage
+
+```hcl
+data "vinyldns_record_sets" "zone_records" {
+  zone_id     = "zone-id"
+  name_filter = "www"
+}
+```
+
+## Arguments Reference
+
+* `zone_id` - (Required) The zone ID to query.
+* `name_filter` - (Optional) Filter record sets by name.
+
+## Attributes Reference
+
+* `record_sets` - List of matching record sets. Each record set includes:
+  * `id` - The record set ID.
+  * `name` - The record set name.
+  * `fqdn` - The record set FQDN.
+  * `type` - The record set type.
+  * `ttl` - The record set TTL.
+  * `owner_group_id` - The owner group ID.
+  * `status` - The record set status.

--- a/docs/data-sources/zones.md
+++ b/docs/data-sources/zones.md
@@ -1,0 +1,28 @@
+# vinyldns_zones
+
+Use this data source to list zones, optionally filtered by name.
+
+## Example Usage
+
+```hcl
+data "vinyldns_zones" "all" {}
+
+data "vinyldns_zones" "filtered" {
+  name_filter = "prod."
+}
+```
+
+## Arguments Reference
+
+* `name_filter` - (Optional) Filter zones by name.
+
+## Attributes Reference
+
+* `zones` - List of matching zones. Each zone includes:
+  * `id` - The zone ID.
+  * `name` - The zone name.
+  * `email` - The zone email.
+  * `admin_group_id` - The admin group ID.
+  * `status` - The zone status.
+  * `shared` - Whether the zone is shared.
+  * `backend_id` - The backend ID.

--- a/vinyldns/data_source_backend_ids.go
+++ b/vinyldns/data_source_backend_ids.go
@@ -1,0 +1,80 @@
+package vinyldns
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/smartystreets/go-aws-auth"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func dataSourceVinylDNSBackendIDs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVinylDNSBackendIDsRead,
+
+		Schema: map[string]*schema.Schema{
+			"backend_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceVinylDNSBackendIDsRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Reading VinylDNS backend IDs")
+
+	ids, err := zoneBackendIDs(meta.(*vinyldns.Client))
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("backend_ids", ids); err != nil {
+		return fmt.Errorf("error setting backend_ids: %s", err)
+	}
+
+	d.SetId("backend-ids")
+
+	return nil
+}
+
+func zoneBackendIDs(client *vinyldns.Client) ([]string, error) {
+	host := strings.TrimRight(client.Host, "/")
+	endpoint := fmt.Sprintf("%s/zones/backendids", host)
+
+	req, err := http.NewRequest("GET", endpoint, bytes.NewReader(nil))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", client.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	awsauth.Sign4(req, awsauth.Credentials{
+		AccessKeyID:     client.AccessKey,
+		SecretAccessKey: client.SecretKey,
+	})
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("unexpected response code from backend ids endpoint: %d", resp.StatusCode)
+	}
+
+	var ids []string
+	if err := json.NewDecoder(resp.Body).Decode(&ids); err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}

--- a/vinyldns/data_source_backend_ids_test.go
+++ b/vinyldns/data_source_backend_ids_test.go
@@ -1,0 +1,26 @@
+package vinyldns
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccVinylDNSBackendIDsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVinylDNSBackendIDsDataSourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vinyldns_backend_ids.test", "backend_ids.0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckVinylDNSBackendIDsDataSourceConfig = `
+data "vinyldns_backend_ids" "test" {}
+`

--- a/vinyldns/data_source_group.go
+++ b/vinyldns/data_source_group.go
@@ -1,0 +1,90 @@
+package vinyldns
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func dataSourceVinylDNSGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVinylDNSGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"member_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"admin_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceVinylDNSGroupRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Reading VinylDNS group %s", name)
+
+	groups, err := meta.(*vinyldns.Client).GroupsListAll(vinyldns.ListFilter{
+		NameFilter: name,
+	})
+	if err != nil {
+		return err
+	}
+
+	var match *vinyldns.Group
+	for i, g := range groups {
+		if g.Name == name {
+			if match != nil {
+				return fmt.Errorf("found multiple groups with name %s", name)
+			}
+			match = &groups[i]
+		}
+	}
+
+	if match == nil {
+		return fmt.Errorf("no group found with name %s", name)
+	}
+
+	d.SetId(match.ID)
+	d.Set("name", match.Name)
+	d.Set("email", match.Email)
+	d.Set("description", match.Description)
+
+	memIDs := make([]interface{}, 0, len(match.Members))
+	for _, m := range match.Members {
+		memIDs = append(memIDs, m.ID)
+	}
+	if err := d.Set("member_ids", schema.NewSet(schema.HashString, memIDs)); err != nil {
+		return fmt.Errorf("error setting member_ids for group %s: %s", match.ID, err)
+	}
+
+	adminIDs := make([]interface{}, 0, len(match.Admins))
+	for _, a := range match.Admins {
+		adminIDs = append(adminIDs, a.ID)
+	}
+	if err := d.Set("admin_ids", schema.NewSet(schema.HashString, adminIDs)); err != nil {
+		return fmt.Errorf("error setting admin_ids for group %s: %s", match.ID, err)
+	}
+
+	return nil
+}

--- a/vinyldns/data_source_group_test.go
+++ b/vinyldns/data_source_group_test.go
@@ -1,0 +1,49 @@
+package vinyldns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func TestAccVinylDNSGroupDataSource_basic(t *testing.T) {
+	name := "terraformdatasourcegroup"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if err := testAccVinylDNSGroupDataSourcePreCheck(t, name); err != nil {
+				t.Fatalf("precheck failed: %s", err)
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVinylDNSGroupDataSourceConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vinyldns_group.test", "name"),
+					resource.TestCheckResourceAttrSet("data.vinyldns_group.test", "email"),
+					resource.TestCheckResourceAttr("data.vinyldns_group.test", "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccVinylDNSGroupDataSourcePreCheck(t *testing.T, name string) error {
+	client := vinyldns.NewClientFromEnv()
+	_, err := ensureTestGroup(client, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckVinylDNSGroupDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+data "vinyldns_group" "test" {
+	name = "%s"
+}
+`, name)
+}

--- a/vinyldns/data_source_helpers_test.go
+++ b/vinyldns/data_source_helpers_test.go
@@ -1,0 +1,135 @@
+package vinyldns
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func ensureTestGroup(client *vinyldns.Client, name string) (*vinyldns.Group, error) {
+	groups, err := client.GroupsListAll(vinyldns.ListFilter{NameFilter: name})
+	if err != nil {
+		return nil, err
+	}
+
+	for i, g := range groups {
+		if g.Name == name {
+			return &groups[i], nil
+		}
+	}
+
+	return client.GroupCreate(&vinyldns.Group{
+		Name:  name,
+		Email: "foo@email.com",
+		Members: []vinyldns.User{
+			{ID: "ok"},
+		},
+		Admins: []vinyldns.User{
+			{ID: "ok"},
+		},
+	})
+}
+
+func ensureTestZone(client *vinyldns.Client, name, adminGroupID string) (*vinyldns.Zone, error) {
+	zone, err := client.ZoneByName(name)
+	if err == nil && zone.ID != "" {
+		return &zone, nil
+	}
+	if err != nil {
+		if vErr, ok := err.(*vinyldns.Error); ok {
+			if vErr.ResponseCode != http.StatusNotFound {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	change, err := client.ZoneCreate(&vinyldns.Zone{
+		Name:         name,
+		Email:        "foo@email.com",
+		AdminGroupID: adminGroupID,
+		Connection: &vinyldns.ZoneConnection{
+			Name:          "vinyldns.",
+			Key:           "nzisn+4G2ldMn0q1CV3vsg==",
+			KeyName:       "vinyldns.",
+			PrimaryServer: "localhost:19001",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	createdZoneID := change.Zone.ID
+	limit := 10
+	for i := 0; i < limit; time.Sleep(10 * time.Second) {
+		i++
+
+		zg, err := client.Zone(createdZoneID)
+		if err == nil && zg.ID == createdZoneID {
+			return &zg, nil
+		}
+
+		if i == (limit - 1) {
+			log.Printf("[INFO] %d retries reached in polling VinylDNS zone %s", limit, createdZoneID)
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("zone %s not available after retries", createdZoneID)
+		}
+	}
+
+	return nil, fmt.Errorf("zone %s not available", createdZoneID)
+}
+
+func ensureTestRecordSet(client *vinyldns.Client, zoneID, name string) error {
+	existing, err := client.RecordSetsListAll(zoneID, vinyldns.ListFilter{NameFilter: name})
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range existing {
+		if rs.Name == name {
+			return nil
+		}
+	}
+
+	_, err = client.RecordSetCreate(&vinyldns.RecordSet{
+		Name:   name,
+		ZoneID: zoneID,
+		Type:   "A",
+		TTL:    300,
+		Records: []vinyldns.Record{
+			{Address: "127.0.0.1"},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	limit := 10
+	for i := 0; i < limit; time.Sleep(5 * time.Second) {
+		i++
+
+		records, err := client.RecordSetsListAll(zoneID, vinyldns.ListFilter{NameFilter: name})
+		if err == nil {
+			for _, rs := range records {
+				if rs.Name == name {
+					return nil
+				}
+			}
+		}
+
+		if i == (limit - 1) {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("record set %s not available after retries", name)
+		}
+	}
+
+	return fmt.Errorf("record set %s not available", name)
+}

--- a/vinyldns/data_source_record_sets.go
+++ b/vinyldns/data_source_record_sets.go
@@ -1,0 +1,99 @@
+package vinyldns
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func dataSourceVinylDNSRecordSets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVinylDNSRecordSetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"record_sets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fqdn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ttl": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"owner_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVinylDNSRecordSetsRead(d *schema.ResourceData, meta interface{}) error {
+	zoneID := d.Get("zone_id").(string)
+	nameFilter := d.Get("name_filter").(string)
+
+	log.Printf("[INFO] Reading VinylDNS record sets (zone_id=%s name_filter=%s)", zoneID, nameFilter)
+
+	filter := vinyldns.ListFilter{
+		NameFilter: nameFilter,
+	}
+
+	records, err := meta.(*vinyldns.Client).RecordSetsListAll(zoneID, filter)
+	if err != nil {
+		return err
+	}
+
+	flattened := make([]interface{}, 0, len(records))
+	for _, rs := range records {
+		flattened = append(flattened, map[string]interface{}{
+			"id":             rs.ID,
+			"name":           rs.Name,
+			"fqdn":           rs.FQDN,
+			"type":           rs.Type,
+			"ttl":            rs.TTL,
+			"owner_group_id": rs.OwnerGroupID,
+			"status":         rs.Status,
+		})
+	}
+
+	if err := d.Set("record_sets", flattened); err != nil {
+		return fmt.Errorf("error setting record_sets for zone %s: %s", zoneID, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", zoneID, nameFilter))
+
+	return nil
+}

--- a/vinyldns/data_source_record_sets_test.go
+++ b/vinyldns/data_source_record_sets_test.go
@@ -1,0 +1,65 @@
+package vinyldns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func TestAccVinylDNSRecordSetsDataSource_basic(t *testing.T) {
+	zoneName := "terraformdatasourcezone."
+	groupName := "terraformdatasourcezonegroup"
+	recordSetName := "terraformdatasourcerecordset"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if err := testAccVinylDNSRecordSetsDataSourcePreCheck(t, groupName, zoneName, recordSetName); err != nil {
+				t.Fatalf("precheck failed: %s", err)
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVinylDNSRecordSetsDataSourceConfig(zoneName, recordSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vinyldns_record_sets.test", "record_sets.0.name", recordSetName),
+					resource.TestCheckResourceAttr("data.vinyldns_record_sets.test", "record_sets.0.type", "A"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVinylDNSRecordSetsDataSourcePreCheck(t *testing.T, groupName, zoneName, recordSetName string) error {
+	client := vinyldns.NewClientFromEnv()
+	group, err := ensureTestGroup(client, groupName)
+	if err != nil {
+		return err
+	}
+
+	zone, err := ensureTestZone(client, zoneName, group.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureTestRecordSet(client, zone.ID, recordSetName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckVinylDNSRecordSetsDataSourceConfig(zoneName, recordSetName string) string {
+	return fmt.Sprintf(`
+data "vinyldns_zone" "test" {
+	name = "%s"
+}
+
+data "vinyldns_record_sets" "test" {
+	zone_id = "${data.vinyldns_zone.test.id}"
+	name_filter = "%s"
+}
+`, zoneName, recordSetName)
+}

--- a/vinyldns/data_source_zones.go
+++ b/vinyldns/data_source_zones.go
@@ -1,0 +1,98 @@
+package vinyldns
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func dataSourceVinylDNSZones() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVinylDNSZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"admin_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shared": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"backend_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVinylDNSZonesRead(d *schema.ResourceData, meta interface{}) error {
+	nameFilter := d.Get("name_filter").(string)
+
+	log.Printf("[INFO] Reading VinylDNS zones (name_filter=%s)", nameFilter)
+
+	filter := vinyldns.ListFilter{
+		NameFilter: nameFilter,
+	}
+
+	zones, err := meta.(*vinyldns.Client).ZonesListAll(filter)
+	if err != nil {
+		return err
+	}
+
+	flattened := make([]interface{}, 0, len(zones))
+	for _, zone := range zones {
+		flattened = append(flattened, map[string]interface{}{
+			"id":             zone.ID,
+			"name":           zone.Name,
+			"email":          zone.Email,
+			"admin_group_id": zone.AdminGroupID,
+			"status":         zone.Status,
+			"shared":         zone.Shared,
+			"backend_id":     zone.BackendID,
+		})
+	}
+
+	if err := d.Set("zones", flattened); err != nil {
+		return fmt.Errorf("error setting zones: %s", err)
+	}
+
+	if nameFilter == "" {
+		d.SetId("zones:all")
+	} else {
+		d.SetId(fmt.Sprintf("zones:%s", nameFilter))
+	}
+
+	return nil
+}

--- a/vinyldns/data_source_zones_test.go
+++ b/vinyldns/data_source_zones_test.go
@@ -1,0 +1,55 @@
+package vinyldns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func TestAccVinylDNSZonesDataSource_basic(t *testing.T) {
+	zoneName := "terraformdatasourcezone."
+	groupName := "terraformdatasourcezonegroup"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if err := testAccVinylDNSZonesDataSourcePreCheck(t, groupName, zoneName); err != nil {
+				t.Fatalf("precheck failed: %s", err)
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVinylDNSZonesDataSourceConfig(zoneName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vinyldns_zones.test", "zones.0.name", zoneName),
+					resource.TestCheckResourceAttrSet("data.vinyldns_zones.test", "zones.0.admin_group_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVinylDNSZonesDataSourcePreCheck(t *testing.T, groupName, zoneName string) error {
+	client := vinyldns.NewClientFromEnv()
+	group, err := ensureTestGroup(client, groupName)
+	if err != nil {
+		return err
+	}
+
+	_, err = ensureTestZone(client, zoneName, group.ID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckVinylDNSZonesDataSourceConfig(zoneName string) string {
+	return fmt.Sprintf(`
+data "vinyldns_zones" "test" {
+	name_filter = "%s"
+}
+`, zoneName)
+}

--- a/vinyldns/provider.go
+++ b/vinyldns/provider.go
@@ -48,7 +48,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"vinyldns_zone": dataSourceVinylDNSZone(),
+			"vinyldns_zone":        dataSourceVinylDNSZone(),
+			"vinyldns_group":       dataSourceVinylDNSGroup(),
+			"vinyldns_zones":       dataSourceVinylDNSZones(),
+			"vinyldns_record_sets": dataSourceVinylDNSRecordSets(),
+			"vinyldns_backend_ids": dataSourceVinylDNSBackendIDs(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
## Summary
- add data sources for groups, zones, record sets, and backend IDs
- register new data sources in the provider
- add docs and sidebar entries for new data sources
- add acceptance tests for each new data source

## Data Sources
- `vinyldns_group` (lookup group by name)
- `vinyldns_zones` (list/filter zones)
- `vinyldns_record_sets` (list record sets in a zone)
- `vinyldns_backend_ids` (list backend IDs)

## Testing
- not run (acceptance tests require local quickstart)
